### PR TITLE
Add Phone Home capability and refactor code

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 group 'com.blackducksoftware.integration.fortify'
-version = '2.0.2'
+version = '2.0.3'
 
 mainClassName = 'com.blackducksoftware.integration.fortify.Application'
 
@@ -135,4 +135,10 @@ publishing{
 
 jacocoTestReport {
     reports { xml.enabled = true }
+}
+
+processResources { 
+	filesMatching("**/application*.properties") { 
+		expand(project.properties)
+	}
 }

--- a/src/main/java/com/blackducksoftware/integration/fortify/batch/job/BlackDuckFortifyJobConfig.java
+++ b/src/main/java/com/blackducksoftware/integration/fortify/batch/job/BlackDuckFortifyJobConfig.java
@@ -44,7 +44,9 @@ import org.springframework.scheduling.annotation.Scheduled;
 
 import com.blackducksoftware.integration.fortify.batch.BatchSchedulerConfig;
 import com.blackducksoftware.integration.fortify.batch.step.Initializer;
+import com.blackducksoftware.integration.fortify.batch.util.AttributeConstants;
 import com.blackducksoftware.integration.fortify.batch.util.MappingParser;
+import com.blackducksoftware.integration.fortify.batch.util.PropertyConstants;
 import com.blackducksoftware.integration.fortify.service.FortifyApplicationVersionApi;
 import com.blackducksoftware.integration.fortify.service.FortifyAttributeDefinitionApi;
 import com.blackducksoftware.integration.fortify.service.FortifyFileTokenApi;
@@ -70,6 +72,12 @@ public class BlackDuckFortifyJobConfig implements JobExecutionListener {
     @Autowired
     private StepBuilderFactory stepBuilderFactory;
 
+    @Autowired
+    private PropertyConstants propertyConstants;
+
+    @Autowired
+    private AttributeConstants attributeConstants;
+
     /**
      * Created the bean for Fortify Application Version Api
      *
@@ -77,7 +85,7 @@ public class BlackDuckFortifyJobConfig implements JobExecutionListener {
      */
     @Bean
     public FortifyApplicationVersionApi getFortifyApplicationVersionApi() {
-        return new FortifyApplicationVersionApi();
+        return new FortifyApplicationVersionApi(propertyConstants);
     }
 
     /**
@@ -87,7 +95,7 @@ public class BlackDuckFortifyJobConfig implements JobExecutionListener {
      */
     @Bean
     public FortifyAttributeDefinitionApi getFortifyAttributeDefinitionApi() {
-        return new FortifyAttributeDefinitionApi();
+        return new FortifyAttributeDefinitionApi(propertyConstants);
     }
 
     /**
@@ -97,7 +105,7 @@ public class BlackDuckFortifyJobConfig implements JobExecutionListener {
      */
     @Bean
     public FortifyFileTokenApi getFortifyFileTokenApi() {
-        return new FortifyFileTokenApi();
+        return new FortifyFileTokenApi(propertyConstants);
     }
 
     /**
@@ -107,7 +115,7 @@ public class BlackDuckFortifyJobConfig implements JobExecutionListener {
      */
     @Bean
     public FortifyUploadApi getFortifyUploadApi() {
-        return new FortifyUploadApi();
+        return new FortifyUploadApi(propertyConstants);
     }
 
     /**
@@ -117,7 +125,7 @@ public class BlackDuckFortifyJobConfig implements JobExecutionListener {
      */
     @Bean
     public MappingParser getMappingParser() {
-        return new MappingParser(getFortifyApplicationVersionApi(), getFortifyAttributeDefinitionApi());
+        return new MappingParser(getFortifyApplicationVersionApi(), getFortifyAttributeDefinitionApi(), propertyConstants, attributeConstants);
     }
 
     /**
@@ -127,7 +135,7 @@ public class BlackDuckFortifyJobConfig implements JobExecutionListener {
      */
     @Bean
     public Initializer getMappingParserTask() {
-        return new Initializer(getMappingParser(), getFortifyFileTokenApi(), getFortifyUploadApi());
+        return new Initializer(getMappingParser(), getFortifyFileTokenApi(), getFortifyUploadApi(), propertyConstants);
     }
 
     /**

--- a/src/main/java/com/blackducksoftware/integration/fortify/batch/job/BlackDuckFortifyPhoneHomeJobConfig.java
+++ b/src/main/java/com/blackducksoftware/integration/fortify/batch/job/BlackDuckFortifyPhoneHomeJobConfig.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2017 Black Duck Software Inc.
+ * http://www.blackducksoftware.com/
+ * All rights reserved.
+ *
+ * This software is the confidential and proprietary information of
+ * Black Duck Software ("Confidential Information"). You shall not
+ * disclose such Confidential Information and shall use it only in
+ * accordance with the terms of the license agreement you entered into
+ * with Black Duck Software.
+ */
+package com.blackducksoftware.integration.fortify.batch.job;
+
+import java.util.Date;
+
+import org.apache.log4j.Logger;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobExecutionListener;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
+import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.scheduling.annotation.Scheduled;
+
+import com.blackducksoftware.integration.fortify.batch.BatchSchedulerConfig;
+import com.blackducksoftware.integration.fortify.batch.step.BlackDuckFortifyPhoneHomeStep;
+import com.blackducksoftware.integration.fortify.batch.util.HubServices;
+import com.blackducksoftware.integration.fortify.batch.util.PropertyConstants;
+
+/**
+ * @author jfisher
+ *
+ */
+@Configuration
+@EnableBatchProcessing
+public class BlackDuckFortifyPhoneHomeJobConfig implements JobExecutionListener {
+    private static final Logger logger = Logger.getLogger(BlackDuckFortifyPhoneHomeJobConfig.class);
+
+    private final BatchSchedulerConfig batchSchedulerConfig;
+
+    private final JobBuilderFactory jobBuilderFactory;
+
+    private final StepBuilderFactory stepBuilderFactory;
+
+    private final HubServices hubServices;
+
+    private final PropertyConstants propertyConstants;
+
+    @Autowired
+    public BlackDuckFortifyPhoneHomeJobConfig(BatchSchedulerConfig batchSchedulerConfig, JobBuilderFactory jobBuilderFactory,
+            StepBuilderFactory stepBuilderFactory, HubServices hubServices, PropertyConstants propertyConstants) {
+        this.batchSchedulerConfig = batchSchedulerConfig;
+        this.jobBuilderFactory = jobBuilderFactory;
+        this.stepBuilderFactory = stepBuilderFactory;
+        this.hubServices = hubServices;
+        this.propertyConstants = propertyConstants;
+    }
+
+    /**
+     * Create the task executor
+     *
+     * @return TaskExecutor
+     */
+    @Bean
+    public TaskExecutor taskExecutor() {
+        SimpleAsyncTaskExecutor asyncTaskExecutor = new SimpleAsyncTaskExecutor("fortifyssc-phonehome");
+        asyncTaskExecutor.setConcurrencyLimit(SimpleAsyncTaskExecutor.NO_CONCURRENCY);
+        return asyncTaskExecutor;
+    }
+
+    /**
+     * Schedule the job and add it to the job launcher
+     *
+     * @throws Exception
+     */
+    @Scheduled(cron = "${cron.expressions}") // Run on same schedule as worker
+    public void execute() throws Exception {
+        JobParameters jobParams = new JobParametersBuilder().addString("JobID", String.valueOf(System.currentTimeMillis())).toJobParameters();
+        batchSchedulerConfig.jobLauncher().run(sendPhoneHomeDataJob(), jobParams);
+    }
+
+    @Bean
+    public Job sendPhoneHomeDataJob() {
+        logger.info("Send Phone Home Data back to Black Duck Software Job");
+        return jobBuilderFactory.get("Send Phone Home Data back to Black Duck Software Job").listener(this).start(sendPhoneHomeDataStep()).build();
+    }
+
+    @Bean
+    public Step sendPhoneHomeDataStep() {
+        logger.info("Send Phone Home Data to Black Duck Software");
+        return stepBuilderFactory.get("Send Phone Home Data to Black Duck Software").tasklet(getFortifyPhoneHomeTask()).build();
+    }
+
+    @Bean
+    public Tasklet getFortifyPhoneHomeTask() {
+        return new BlackDuckFortifyPhoneHomeStep(hubServices, propertyConstants);
+    }
+
+    /**
+     * Executed before the job begins
+     */
+    @Override
+    public void beforeJob(JobExecution jobExecution) {
+        logger.info("Job started at: " + new Date());
+    }
+
+    /**
+     * Executed after the job completes
+     */
+    @Override
+    public void afterJob(JobExecution jobExecution) {
+        logger.info("Job completed at: " + new Date());
+    }
+
+}

--- a/src/main/java/com/blackducksoftware/integration/fortify/batch/job/SpringConfiguration.java
+++ b/src/main/java/com/blackducksoftware/integration/fortify/batch/job/SpringConfiguration.java
@@ -24,7 +24,6 @@ package com.blackducksoftware.integration.fortify.batch.job;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Scope;
 
 import com.blackducksoftware.integration.fortify.batch.util.HubServices;
 import com.blackducksoftware.integration.fortify.batch.util.PropertyConstants;
@@ -38,7 +37,6 @@ public class SpringConfiguration {
      * @return
      */
     @Bean
-    @Scope("prototype")
     public HubServices getHubServices(PropertyConstants propertyConstants) {
         return new HubServices(RestConnectionHelper.createHubServicesFactory(propertyConstants));
     }

--- a/src/main/java/com/blackducksoftware/integration/fortify/batch/job/SpringConfiguration.java
+++ b/src/main/java/com/blackducksoftware/integration/fortify/batch/job/SpringConfiguration.java
@@ -23,12 +23,15 @@
 package com.blackducksoftware.integration.fortify.batch.job;
 
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Scope;
 
 import com.blackducksoftware.integration.fortify.batch.util.HubServices;
+import com.blackducksoftware.integration.fortify.batch.util.PropertyConstants;
 import com.blackducksoftware.integration.fortify.batch.util.RestConnectionHelper;
 
-public final class SpringConfiguration {
+@Configuration
+public class SpringConfiguration {
     /**
      * Created the bean to get the instance of Hub Services
      *
@@ -36,7 +39,7 @@ public final class SpringConfiguration {
      */
     @Bean
     @Scope("prototype")
-    public HubServices getHubServices() {
-        return new HubServices(RestConnectionHelper.createHubServicesFactory());
+    public HubServices getHubServices(PropertyConstants propertyConstants) {
+        return new HubServices(RestConnectionHelper.createHubServicesFactory(propertyConstants));
     }
 }

--- a/src/main/java/com/blackducksoftware/integration/fortify/batch/step/BlackDuckFortifyPhoneHomeStep.java
+++ b/src/main/java/com/blackducksoftware/integration/fortify/batch/step/BlackDuckFortifyPhoneHomeStep.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2017 Black Duck Software Inc.
+ * http://www.blackducksoftware.com/
+ * All rights reserved.
+ *
+ * This software is the confidential and proprietary information of
+ * Black Duck Software ("Confidential Information"). You shall not
+ * disclose such Confidential Information and shall use it only in
+ * accordance with the terms of the license agreement you entered into
+ * with Black Duck Software.
+ */
+package com.blackducksoftware.integration.fortify.batch.step;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import org.apache.log4j.Logger;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+
+import com.blackducksoftware.integration.fortify.batch.util.HubServices;
+import com.blackducksoftware.integration.fortify.batch.util.PropertyConstants;
+import com.blackducksoftware.integration.hub.dataservice.phonehome.PhoneHomeDataService;
+import com.blackducksoftware.integration.phonehome.PhoneHomeRequestBodyBuilder;
+import com.blackducksoftware.integration.phonehome.enums.PhoneHomeSource;
+import com.blackducksoftware.integration.phonehome.enums.ThirdPartyName;
+
+/**
+ * @author jfisher
+ *
+ */
+public class BlackDuckFortifyPhoneHomeStep implements Tasklet, StepExecutionListener {
+    private final static Logger logger = Logger.getLogger(BlackDuckFortifyPhoneHomeStep.class);
+
+    private String startJobTimeStamp;
+
+    private HubServices hubServices;
+
+    private PropertyConstants propertyConstants;
+
+    /**
+     * Constructor
+     *
+     * @param hubServices
+     *            HubServices object which provides access to the Hub
+     */
+    public BlackDuckFortifyPhoneHomeStep(HubServices hubServices, PropertyConstants propertyConstants) {
+        super();
+        this.hubServices = hubServices;
+        this.propertyConstants = propertyConstants;
+    }
+
+    /**
+     * This executes before the step and stores the start time of the step
+     */
+    @Override
+    public void beforeStep(StepExecution stepExecution) {
+        startJobTimeStamp = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss.SSS").format(LocalDateTime.now());
+    }
+
+    /**
+     * This executes after the step and will log the start and end time of the step
+     */
+    @Override
+    public ExitStatus afterStep(StepExecution stepExecution) {
+        String stopJobTimeStamp = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss.SSS").format(LocalDateTime.now());
+        logger.info("Phone Home execution step started: " + startJobTimeStamp + " and ended: " + stopJobTimeStamp);
+        return ExitStatus.COMPLETED;
+    }
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
+        logger.info("Started Phone Home step");
+
+        PhoneHomeDataService phoneHome = hubServices.getPhoneHomeDataService();
+        PhoneHomeRequestBodyBuilder phoneHomeReq = phoneHome.createInitialPhoneHomeRequestBodyBuilder();
+        phoneHomeReq.setSource(PhoneHomeSource.ALLIANCES);
+        phoneHomeReq.setThirdPartyName(ThirdPartyName.FORTIFY_SSC);
+        phoneHomeReq.setThirdPartyVersion("N/A");
+        phoneHomeReq.setPluginVersion(propertyConstants.getPluginVersion());
+
+        phoneHome.phoneHome(phoneHomeReq.build());
+
+        return RepeatStatus.FINISHED;
+    }
+
+}

--- a/src/main/java/com/blackducksoftware/integration/fortify/batch/step/BlackDuckFortifyPhoneHomeStep.java
+++ b/src/main/java/com/blackducksoftware/integration/fortify/batch/step/BlackDuckFortifyPhoneHomeStep.java
@@ -39,9 +39,9 @@ public class BlackDuckFortifyPhoneHomeStep implements Tasklet, StepExecutionList
 
     private String startJobTimeStamp;
 
-    private HubServices hubServices;
+    private final HubServices hubServices;
 
-    private PropertyConstants propertyConstants;
+    private final PropertyConstants propertyConstants;
 
     /**
      * Constructor
@@ -50,7 +50,6 @@ public class BlackDuckFortifyPhoneHomeStep implements Tasklet, StepExecutionList
      *            HubServices object which provides access to the Hub
      */
     public BlackDuckFortifyPhoneHomeStep(HubServices hubServices, PropertyConstants propertyConstants) {
-        super();
         this.hubServices = hubServices;
         this.propertyConstants = propertyConstants;
     }

--- a/src/main/java/com/blackducksoftware/integration/fortify/batch/util/AttributeConstants.java
+++ b/src/main/java/com/blackducksoftware/integration/fortify/batch/util/AttributeConstants.java
@@ -28,21 +28,25 @@ import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Properties;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+
 /**
  * This class will hold all the key value pairs that are specified in the attributes.properties file
  *
  * @author smanikantan
  *
  */
+@Configuration
 public class AttributeConstants {
 
-    private static final Properties properties = new Properties();
+    private final Properties properties = new Properties();
 
-    private static final String attributesFileName = PropertyConstants.getAttributeFilePath();
+    private final HashMap<Object, Object> hmProps = new HashMap<>();
 
-    private static final HashMap<Object, Object> hmProps = new HashMap<>();
-
-    static {
+    @Autowired
+    public AttributeConstants(PropertyConstants propertyConstants) {
+        String attributesFileName = propertyConstants.getAttributeFilePath();
         InputStream attributeConfig = null;
         try {
             attributeConfig = new java.io.FileInputStream(attributesFileName);
@@ -70,7 +74,7 @@ public class AttributeConstants {
      *            the key
      * @return the property
      */
-    public static String getProperty(String key) {
+    public String getProperty(String key) {
         if (hmProps.containsKey(key)) {
             return (String) hmProps.get(key);
         } else {

--- a/src/main/java/com/blackducksoftware/integration/fortify/batch/util/HubServices.java
+++ b/src/main/java/com/blackducksoftware/integration/fortify/batch/util/HubServices.java
@@ -224,7 +224,7 @@ public final class HubServices {
 
     public PhoneHomeDataService getPhoneHomeDataService() {
         logger.info("Getting Phone Home Data Service");
-        final PhoneHomeDataService phoneHomeDataService = hubServicesFactory.createPhoneHomeDataService(hubServicesFactory.getRestConnection().logger);
+        final PhoneHomeDataService phoneHomeDataService = hubServicesFactory.createPhoneHomeDataService();
         return phoneHomeDataService;
     }
 }

--- a/src/main/java/com/blackducksoftware/integration/fortify/batch/util/HubServices.java
+++ b/src/main/java/com/blackducksoftware/integration/fortify/batch/util/HubServices.java
@@ -35,6 +35,7 @@ import com.blackducksoftware.integration.fortify.batch.model.VulnerableComponent
 import com.blackducksoftware.integration.hub.api.item.MetaService;
 import com.blackducksoftware.integration.hub.api.project.ProjectRequestService;
 import com.blackducksoftware.integration.hub.api.project.version.ProjectVersionRequestService;
+import com.blackducksoftware.integration.hub.dataservice.phonehome.PhoneHomeDataService;
 import com.blackducksoftware.integration.hub.exception.HubIntegrationException;
 import com.blackducksoftware.integration.hub.model.view.ProjectVersionView;
 import com.blackducksoftware.integration.hub.model.view.ProjectView;
@@ -219,5 +220,11 @@ public final class HubServices {
             return riskProfile.getBomLastUpdatedAt();
         }
         return null;
+    }
+
+    public PhoneHomeDataService getPhoneHomeDataService() {
+        logger.info("Getting Phone Home Data Service");
+        final PhoneHomeDataService phoneHomeDataService = hubServicesFactory.createPhoneHomeDataService(hubServicesFactory.getRestConnection().logger);
+        return phoneHomeDataService;
     }
 }

--- a/src/main/java/com/blackducksoftware/integration/fortify/batch/util/PropertyConstants.java
+++ b/src/main/java/com/blackducksoftware/integration/fortify/batch/util/PropertyConstants.java
@@ -34,202 +34,212 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class PropertyConstants {
 
-    private static String hubUserName;
+    private String hubUserName;
 
     @Value("${hub.username}")
     public void setHubUserName(String hubUserName) {
-        PropertyConstants.hubUserName = hubUserName;
+        this.hubUserName = hubUserName;
     }
 
-    private static String hubPassword;
+    private String hubPassword;
 
     @Value("${hub.password}")
     public void setHubPassword(String hubPassword) {
-        PropertyConstants.hubPassword = hubPassword;
+        this.hubPassword = hubPassword;
     }
 
-    private static String hubTimeout;
+    private String hubTimeout;
 
     @Value("${hub.timeout}")
     public void setHubTimeout(String hubTimeout) {
-        PropertyConstants.hubTimeout = hubTimeout;
+        this.hubTimeout = hubTimeout;
     }
 
-    private static String hubServerUrl;
+    private String hubServerUrl;
 
     @Value("${hub.server.url}")
     public void setHubServerUrl(String hubServerUrl) {
-        PropertyConstants.hubServerUrl = hubServerUrl;
+        this.hubServerUrl = hubServerUrl;
     }
 
-    private static String hubProxyHost;
+    private String hubProxyHost;
 
     @Value("${hub.proxy.host}")
     public void setHubProxyHost(String hubProxyHost) {
-        PropertyConstants.hubProxyHost = hubProxyHost;
+        this.hubProxyHost = hubProxyHost;
     }
 
-    private static String hubProxyPort;
+    private String hubProxyPort;
 
     @Value("${hub.proxy.port}")
     public void setHubProxyPort(String hubProxyPort) {
-        PropertyConstants.hubProxyPort = hubProxyPort;
+        this.hubProxyPort = hubProxyPort;
     }
 
-    private static String hubProxyUser;
+    private String hubProxyUser;
 
     @Value("${hub.proxy.user}")
     public void setHubProxyUser(String hubProxyUser) {
-        PropertyConstants.hubProxyUser = hubProxyUser;
+        this.hubProxyUser = hubProxyUser;
     }
 
-    private static String hubProxyPassword;
+    private String hubProxyPassword;
 
     @Value("${hub.proxy.password}")
     public void setHubProxyPassword(String hubProxyPassword) {
-        PropertyConstants.hubProxyPassword = hubProxyPassword;
+        this.hubProxyPassword = hubProxyPassword;
     }
 
-    private static String hubProxyNoHost;
+    private String hubProxyNoHost;
 
     @Value("${hub.proxy.nohost}")
     public void setHubProxyNoHost(String hubProxyNoHost) {
-        PropertyConstants.hubProxyNoHost = hubProxyNoHost;
+        this.hubProxyNoHost = hubProxyNoHost;
     }
 
-    private static String fortifyUserName;
+    private String fortifyUserName;
 
     @Value("${fortify.username}")
     public void setFortifyUserName(String fortifyUserName) {
-        PropertyConstants.fortifyUserName = fortifyUserName;
+        this.fortifyUserName = fortifyUserName;
     }
 
-    private static String fortifyPassword;
+    private String fortifyPassword;
 
     @Value("${fortify.password}")
     public void setFortifyPassword(String fortifyPassword) {
-        PropertyConstants.fortifyPassword = fortifyPassword;
+        this.fortifyPassword = fortifyPassword;
     }
 
-    private static String fortifyServerUrl;
+    private String fortifyServerUrl;
 
     @Value("${fortify.server.url}")
     public void setFortifyServerUrl(String fortifyServerUrl) {
-        PropertyConstants.fortifyServerUrl = fortifyServerUrl;
+        this.fortifyServerUrl = fortifyServerUrl;
     }
 
-    private static String batchJobStatusFilePath;
+    private String batchJobStatusFilePath;
 
     @Value("${hub.fortify.batch.job.status.file.path}")
     public void setBatchJobStatusFilePath(String batchJobStatusFilePath) {
-        PropertyConstants.batchJobStatusFilePath = batchJobStatusFilePath;
+        this.batchJobStatusFilePath = batchJobStatusFilePath;
     }
 
-    private static String reportDir;
+    private String reportDir;
 
     @Value("${hub.fortify.report.dir}")
     public void setReportDir(String reportDir) {
-        PropertyConstants.reportDir = reportDir;
+        this.reportDir = reportDir;
     }
 
-    private static String mappingJsonPath;
+    private String mappingJsonPath;
 
     @Value("${hub.fortify.mapping.file.path}")
     public void setMappingJsonPath(String mappingJsonPath) {
-        PropertyConstants.mappingJsonPath = mappingJsonPath;
+        this.mappingJsonPath = mappingJsonPath;
     }
 
-    private static String attributeFilePath;
+    private String attributeFilePath;
 
     @Value("${attribute.file}")
     public void setAttributeFilePath(String attributeFilePath) {
-        PropertyConstants.attributeFilePath = attributeFilePath;
+        this.attributeFilePath = attributeFilePath;
     }
 
-    private static int maximumThreadSize;
+    private int maximumThreadSize;
 
     @Value("${maximum.thread.size}")
     public void setMaximumThreadSize(int maximumThreadSize) {
-        PropertyConstants.maximumThreadSize = maximumThreadSize;
+        this.maximumThreadSize = maximumThreadSize;
     }
 
-    private static boolean batchJobStatusCheck;
+    private boolean batchJobStatusCheck;
 
     @Value("${batch.job.status.check}")
     public void setBatchJobStatusCheck(boolean batchJobStatusCheck) {
-        PropertyConstants.batchJobStatusCheck = batchJobStatusCheck;
+        this.batchJobStatusCheck = batchJobStatusCheck;
     }
 
-    public static String getHubUserName() {
+    private String pluginVersion;
+
+    @Value("${plugin.version}")
+    public void setPluginVersion(String pluginVersion) {
+        this.pluginVersion = pluginVersion;
+    }
+
+    public String getHubUserName() {
         return hubUserName;
     }
 
-    public static String getHubPassword() {
+    public String getHubPassword() {
         return hubPassword;
     }
 
-    public static String getHubTimeout() {
+    public String getHubTimeout() {
         return hubTimeout;
     }
 
-    public static String getHubServerUrl() {
+    public String getHubServerUrl() {
         return hubServerUrl;
     }
 
-    public static String getHubProxyHost() {
+    public String getHubProxyHost() {
         return hubProxyHost;
     }
 
-    public static String getHubProxyPort() {
+    public String getHubProxyPort() {
         return hubProxyPort;
     }
 
-    public static String getHubProxyUser() {
+    public String getHubProxyUser() {
         return hubProxyUser;
     }
 
-    public static String getHubProxyPassword() {
+    public String getHubProxyPassword() {
         return hubProxyPassword;
     }
 
-    public static String getHubProxyNoHost() {
+    public String getHubProxyNoHost() {
         return hubProxyNoHost;
     }
 
-    public static String getFortifyUserName() {
+    public String getFortifyUserName() {
         return fortifyUserName;
     }
 
-    public static String getFortifyPassword() {
+    public String getFortifyPassword() {
         return fortifyPassword;
     }
 
-    public static String getFortifyServerUrl() {
+    public String getFortifyServerUrl() {
         return fortifyServerUrl;
     }
 
-    public static String getBatchJobStatusFilePath() {
+    public String getBatchJobStatusFilePath() {
         return batchJobStatusFilePath;
     }
 
-    public static String getReportDir() {
+    public String getReportDir() {
         return reportDir;
     }
 
-    public static String getMappingJsonPath() {
+    public String getMappingJsonPath() {
         return mappingJsonPath;
     }
 
-    public static String getAttributeFilePath() {
+    public String getAttributeFilePath() {
         return attributeFilePath;
     }
 
-    public static int getMaximumThreadSize() {
+    public int getMaximumThreadSize() {
         return maximumThreadSize;
     }
 
-    public static boolean isBatchJobStatusCheck() {
+    public boolean isBatchJobStatusCheck() {
         return batchJobStatusCheck;
     }
 
+    public String getPluginVersion() {
+        return pluginVersion;
+    }
 }

--- a/src/main/java/com/blackducksoftware/integration/fortify/batch/util/RestConnectionHelper.java
+++ b/src/main/java/com/blackducksoftware/integration/fortify/batch/util/RestConnectionHelper.java
@@ -49,20 +49,20 @@ public final class RestConnectionHelper {
      *
      * @return
      */
-    private static HubServerConfig getHubServerConfig() {
+    private static HubServerConfig getHubServerConfig(PropertyConstants propertyConstants) {
         HubServerConfigBuilder builder = new HubServerConfigBuilder();
-        builder.setHubUrl(PropertyConstants.getHubServerUrl());
-        builder.setUsername(PropertyConstants.getHubUserName());
-        builder.setPassword(PropertyConstants.getHubPassword());
-        builder.setTimeout(PropertyConstants.getHubTimeout());
+        builder.setHubUrl(propertyConstants.getHubServerUrl());
+        builder.setUsername(propertyConstants.getHubUserName());
+        builder.setPassword(propertyConstants.getHubPassword());
+        builder.setTimeout(propertyConstants.getHubTimeout());
 
-        if (PropertyConstants.getHubProxyHost() != null && !"".equalsIgnoreCase(PropertyConstants.getHubProxyHost())) {
-            logger.info("Inside Proxy settings::" + PropertyConstants.getHubProxyHost() + "::");
-            builder.setProxyHost(PropertyConstants.getHubProxyHost());
-            builder.setProxyPort(PropertyConstants.getHubProxyPort());
-            builder.setProxyUsername(PropertyConstants.getHubProxyUser());
-            builder.setProxyPassword(PropertyConstants.getHubPassword());
-            builder.setIgnoredProxyHosts(PropertyConstants.getHubProxyNoHost());
+        if (propertyConstants.getHubProxyHost() != null && !"".equalsIgnoreCase(propertyConstants.getHubProxyHost())) {
+            logger.info("Inside Proxy settings::" + propertyConstants.getHubProxyHost() + "::");
+            builder.setProxyHost(propertyConstants.getHubProxyHost());
+            builder.setProxyPort(propertyConstants.getHubProxyPort());
+            builder.setProxyUsername(propertyConstants.getHubProxyUser());
+            builder.setProxyPassword(propertyConstants.getHubPassword());
+            builder.setIgnoredProxyHosts(propertyConstants.getHubProxyNoHost());
         }
 
         return builder.build();
@@ -73,8 +73,8 @@ public final class RestConnectionHelper {
      *
      * @return
      */
-    private static CredentialsRestConnection getApplicationPropertyRestConnection() {
-        return getRestConnection(getHubServerConfig());
+    private static CredentialsRestConnection getApplicationPropertyRestConnection(final PropertyConstants propertyConstants) {
+        return getRestConnection(getHubServerConfig(propertyConstants));
     }
 
     /**
@@ -124,8 +124,8 @@ public final class RestConnectionHelper {
      *
      * @return
      */
-    public static HubServicesFactory createHubServicesFactory() {
-        return createHubServicesFactory(LogLevel.DEBUG);
+    public static HubServicesFactory createHubServicesFactory(PropertyConstants propertyConstants) {
+        return createHubServicesFactory(LogLevel.DEBUG, propertyConstants);
     }
 
     /**
@@ -134,8 +134,8 @@ public final class RestConnectionHelper {
      * @param logLevel
      * @return
      */
-    private static HubServicesFactory createHubServicesFactory(final LogLevel logLevel) {
-        return createHubServicesFactory(new PrintStreamIntLogger(System.out, logLevel));
+    private static HubServicesFactory createHubServicesFactory(final LogLevel logLevel, final PropertyConstants propertyConstants) {
+        return createHubServicesFactory(new PrintStreamIntLogger(System.out, logLevel), propertyConstants);
     }
 
     /**
@@ -144,8 +144,8 @@ public final class RestConnectionHelper {
      * @param logger
      * @return
      */
-    private static HubServicesFactory createHubServicesFactory(final IntLogger logger) {
-        final RestConnection restConnection = getApplicationPropertyRestConnection();
+    private static HubServicesFactory createHubServicesFactory(final IntLogger logger, final PropertyConstants propertyConstants) {
+        final RestConnection restConnection = getApplicationPropertyRestConnection(propertyConstants);
         restConnection.logger = logger;
         final HubServicesFactory hubServicesFactory = new HubServicesFactory(restConnection);
         return hubServicesFactory;

--- a/src/main/java/com/blackducksoftware/integration/fortify/batch/util/VulnerabilityUtil.java
+++ b/src/main/java/com/blackducksoftware/integration/fortify/batch/util/VulnerabilityUtil.java
@@ -80,7 +80,7 @@ public final class VulnerabilityUtil {
      * @return List<Vulnerability>
      */
     public static List<Vulnerability> transformMapping(List<VulnerableComponentView> vulnerabilityComponentViews, String hubProjectName,
-            String hubProjectVersion, Date maxBomUpdatedDate) {
+            String hubProjectVersion, Date maxBomUpdatedDate, PropertyConstants propertyConstants) {
         List<Vulnerability> vulnerabilities = new ArrayList<>();
         vulnerabilityComponentViews.forEach(vulnerableComponentView -> {
             String[] componentVersionLinkArr = vulnerableComponentView.getComponentVersionLink().split("/");
@@ -102,7 +102,7 @@ public final class VulnerabilityUtil {
                     vulnerableComponentView.getVulnerabilityWithRemediation().getExploitabilitySubscore(),
                     vulnerableComponentView.getVulnerabilityWithRemediation().getImpactSubscore(),
                     String.valueOf(vulnerableComponentView.getVulnerabilityWithRemediation().getSource()),
-                    PropertyConstants.getHubServerUrl() + "/ui/vulnerabilities/id:"
+                    propertyConstants.getHubServerUrl() + "/ui/vulnerabilities/id:"
                             + String.valueOf(vulnerableComponentView.getVulnerabilityWithRemediation().getVulnerabilityName()) + "/view:overview",
                     String.valueOf(vulnerableComponentView.getVulnerabilityWithRemediation().getRemediationStatus()),
                     vulnerableComponentView.getVulnerabilityWithRemediation().getRemediationTargetAt(),

--- a/src/main/java/com/blackducksoftware/integration/fortify/service/FortifyApplicationVersionApi.java
+++ b/src/main/java/com/blackducksoftware/integration/fortify/service/FortifyApplicationVersionApi.java
@@ -53,13 +53,20 @@ public final class FortifyApplicationVersionApi extends FortifyService {
 
     private final static Logger logger = Logger.getLogger(MappingParser.class);
 
-    private final static OkHttpClient.Builder okBuilder = getHeader(PropertyConstants.getFortifyUserName(),
-            PropertyConstants.getFortifyPassword());
+    private final OkHttpClient.Builder okBuilder;
 
-    private final static Retrofit retrofit = new Retrofit.Builder().baseUrl(PropertyConstants.getFortifyServerUrl())
-            .addConverterFactory(GsonConverterFactory.create()).client(okBuilder.build()).build();
+    private final Retrofit retrofit;
 
-    private final static FortifyApplicationVersionApiService apiService = retrofit.create(FortifyApplicationVersionApiService.class);
+    private final FortifyApplicationVersionApiService apiService;
+
+    public FortifyApplicationVersionApi(final PropertyConstants propertyConstants) {
+        super(propertyConstants);
+        okBuilder = getHeader(propertyConstants.getFortifyUserName(),
+                propertyConstants.getFortifyPassword());
+        retrofit = new Retrofit.Builder().baseUrl(propertyConstants.getFortifyServerUrl())
+                .addConverterFactory(GsonConverterFactory.create()).client(okBuilder.build()).build();
+        apiService = retrofit.create(FortifyApplicationVersionApiService.class);
+    }
 
     public FortifyApplicationResponse getApplicationVersionByName(String fields, String filter) throws IOException, IntegrationException {
         Call<FortifyApplicationResponse> apiApplicationResponseCall = apiService.getApplicationVersionByName(fields, filter);

--- a/src/main/java/com/blackducksoftware/integration/fortify/service/FortifyAttributeDefinitionApi.java
+++ b/src/main/java/com/blackducksoftware/integration/fortify/service/FortifyAttributeDefinitionApi.java
@@ -40,11 +40,11 @@ public final class FortifyAttributeDefinitionApi extends FortifyService {
 
     private final static String FIELDS_ATTRIBUTE = "id,name,category,type,options,required";
 
-    private static OkHttpClient.Builder okBuilder;
+    private final OkHttpClient.Builder okBuilder;
 
-    private static Retrofit retrofit;
+    private final Retrofit retrofit;
 
-    private static FortifyAttributeDefinitionApiService apiService;
+    private final FortifyAttributeDefinitionApiService apiService;
 
     public FortifyAttributeDefinitionApi(final PropertyConstants propertyConstants) {
         super(propertyConstants);

--- a/src/main/java/com/blackducksoftware/integration/fortify/service/FortifyAttributeDefinitionApi.java
+++ b/src/main/java/com/blackducksoftware/integration/fortify/service/FortifyAttributeDefinitionApi.java
@@ -40,13 +40,20 @@ public final class FortifyAttributeDefinitionApi extends FortifyService {
 
     private final static String FIELDS_ATTRIBUTE = "id,name,category,type,options,required";
 
-    private final static OkHttpClient.Builder okBuilder = getHeader(PropertyConstants.getFortifyUserName(),
-            PropertyConstants.getFortifyPassword());
+    private static OkHttpClient.Builder okBuilder;
 
-    private final static Retrofit retrofit = new Retrofit.Builder().baseUrl(PropertyConstants.getFortifyServerUrl())
-            .addConverterFactory(GsonConverterFactory.create()).client(okBuilder.build()).build();
+    private static Retrofit retrofit;
 
-    private final static FortifyAttributeDefinitionApiService apiService = retrofit.create(FortifyAttributeDefinitionApiService.class);
+    private static FortifyAttributeDefinitionApiService apiService;
+
+    public FortifyAttributeDefinitionApi(final PropertyConstants propertyConstants) {
+        super(propertyConstants);
+        okBuilder = getHeader(propertyConstants.getFortifyUserName(),
+                propertyConstants.getFortifyPassword());
+        retrofit = new Retrofit.Builder().baseUrl(propertyConstants.getFortifyServerUrl())
+                .addConverterFactory(GsonConverterFactory.create()).client(okBuilder.build()).build();
+        apiService = retrofit.create(FortifyAttributeDefinitionApiService.class);
+    }
 
     public FortifyAttributeDefinitionResponse getAttributeDefinitions() throws IOException, IntegrationException {
         Call<FortifyAttributeDefinitionResponse> apiApplicationResponseCall = apiService.getAttributeDefinitions(FIELDS_ATTRIBUTE, FILTER_REQUIRE_ATTRIBUTE);

--- a/src/main/java/com/blackducksoftware/integration/fortify/service/FortifyFileTokenApi.java
+++ b/src/main/java/com/blackducksoftware/integration/fortify/service/FortifyFileTokenApi.java
@@ -48,13 +48,20 @@ public final class FortifyFileTokenApi extends FortifyService {
 
     private final static Logger logger = Logger.getLogger(FortifyFileTokenApi.class);
 
-    private final OkHttpClient.Builder okBuilder = getHeader(PropertyConstants.getFortifyUserName(),
-            PropertyConstants.getFortifyPassword());
+    private final OkHttpClient.Builder okBuilder;
 
-    private final Retrofit retrofit = new Retrofit.Builder().baseUrl(PropertyConstants.getFortifyServerUrl())
-            .addConverterFactory(GsonConverterFactory.create()).client(okBuilder.build()).build();
+    private final Retrofit retrofit;
 
-    private final FortifyFileTokenApiService apiService = retrofit.create(FortifyFileTokenApiService.class);
+    private final FortifyFileTokenApiService apiService;
+
+    public FortifyFileTokenApi(final PropertyConstants propertyConstants) {
+        super(propertyConstants);
+        okBuilder = getHeader(propertyConstants.getFortifyUserName(),
+                propertyConstants.getFortifyPassword());
+        retrofit = new Retrofit.Builder().baseUrl(propertyConstants.getFortifyServerUrl())
+                .addConverterFactory(GsonConverterFactory.create()).client(okBuilder.build()).build();
+        apiService = retrofit.create(FortifyFileTokenApiService.class);
+    }
 
     /**
      * Get the Fortify File token to upload any files

--- a/src/main/java/com/blackducksoftware/integration/fortify/service/FortifyService.java
+++ b/src/main/java/com/blackducksoftware/integration/fortify/service/FortifyService.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 
 import com.blackducksoftware.integration.exception.IntegrationException;
 import com.blackducksoftware.integration.fortify.batch.util.FortifyExceptionUtil;
+import com.blackducksoftware.integration.fortify.batch.util.PropertyConstants;
 
 import okhttp3.Authenticator;
 import okhttp3.Credentials;
@@ -44,6 +45,16 @@ import okhttp3.logging.HttpLoggingInterceptor.Level;
  *
  */
 public abstract class FortifyService {
+    private final PropertyConstants propertyConstants;
+
+    public FortifyService(PropertyConstants propertyConstants) {
+        this.propertyConstants = propertyConstants;
+    }
+
+    public PropertyConstants getPropertyConstants() {
+        return propertyConstants;
+    }
+
     public static Builder getHeader(String userName, String password) {
         HttpLoggingInterceptor logging = new HttpLoggingInterceptor();
         logging.setLevel(Level.BASIC);

--- a/src/main/java/com/blackducksoftware/integration/fortify/service/FortifyUploadApi.java
+++ b/src/main/java/com/blackducksoftware/integration/fortify/service/FortifyUploadApi.java
@@ -49,12 +49,19 @@ import okhttp3.Response;
 public final class FortifyUploadApi extends FortifyService {
     private final static Logger logger = Logger.getLogger(FortifyUploadApi.class);
 
-    private final static OkHttpClient.Builder okBuilder = getHeader(PropertyConstants.getFortifyUserName(),
-            PropertyConstants.getFortifyPassword());
+    private final OkHttpClient.Builder okBuilder;
 
-    private final static OkHttpClient okHttpClient = okBuilder.build();
+    private final OkHttpClient okHttpClient;
 
-    private final static String URL = PropertyConstants.getFortifyServerUrl() + "upload/resultFileUpload.html?mat=";
+    private final String URL;
+
+    public FortifyUploadApi(final PropertyConstants propertyConstants) {
+        super(propertyConstants);
+        okBuilder = getHeader(propertyConstants.getFortifyUserName(),
+                propertyConstants.getFortifyPassword());
+        okHttpClient = okBuilder.build();
+        URL = propertyConstants.getFortifyServerUrl() + "upload/resultFileUpload.html?mat=";
+    }
 
     /**
      * Upload the vulnerabilities to Fortify

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -39,3 +39,6 @@ logging.pattern.console= %d{MM-dd-yyyy HH:mm:ss,SSS} %-5p [%t] %c:%L %M - %m%n
 
 # Logging pattern for file
 logging.pattern.file= %d{MM-dd-yyyy HH:mm:ss,SSS} %-5p [%t] %c:%L %M - %m%n
+
+# The version of the plugin
+plugin.version=${version}

--- a/src/main/resources/application_prod.properties
+++ b/src/main/resources/application_prod.properties
@@ -39,3 +39,6 @@ logging.pattern.console= %d{MM-dd-yyyy HH:mm:ss,SSS} %-5p [%t] %c:%L %M - %m%n
 
 # Logging pattern for file
 logging.pattern.file= %d{MM-dd-yyyy HH:mm:ss,SSS} %-5p [%t] %c:%L %M - %m%n
+
+# The version of the plugin
+plugin.version=${version}

--- a/src/test/java/com/blackducksoftware/integration/fortify/batch/util/HubServicesTest.java
+++ b/src/test/java/com/blackducksoftware/integration/fortify/batch/util/HubServicesTest.java
@@ -30,10 +30,13 @@ import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import com.blackducksoftware.integration.exception.IntegrationException;
+import com.blackducksoftware.integration.fortify.batch.BatchSchedulerConfig;
 import com.blackducksoftware.integration.fortify.batch.TestApplication;
 import com.blackducksoftware.integration.fortify.batch.job.BlackDuckFortifyJobConfig;
 import com.blackducksoftware.integration.fortify.batch.job.SpringConfiguration;
@@ -47,22 +50,26 @@ import junit.framework.TestCase;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(classes = TestApplication.class)
+@ContextConfiguration(classes = { SpringConfiguration.class, BlackDuckFortifyJobConfig.class, BatchSchedulerConfig.class, PropertyConstants.class })
 public class HubServicesTest extends TestCase {
     private String PROJECT_NAME;
 
     private String VERSION_NAME;
 
-    private BlackDuckFortifyJobConfig blackDuckFortifyJobConfig;
+    @Autowired
+    private HubServices hubServices;
 
-    private SpringConfiguration springConfiguration;
+    @Autowired
+    private MappingParser mappingParser;
+
+    @Autowired
+    private PropertyConstants propertyConstants;
 
     @Override
     @Before
     public void setUp() throws JsonIOException, IOException, IntegrationException {
-        blackDuckFortifyJobConfig = new BlackDuckFortifyJobConfig();
-        springConfiguration = new SpringConfiguration();
-        final List<BlackDuckFortifyMapperGroup> blackDuckFortifyMappers = blackDuckFortifyJobConfig.getMappingParser()
-                .createMapping(PropertyConstants.getMappingJsonPath());
+        final List<BlackDuckFortifyMapperGroup> blackDuckFortifyMappers = mappingParser
+                .createMapping(propertyConstants.getMappingJsonPath());
         PROJECT_NAME = blackDuckFortifyMappers.get(0).getHubProjectVersion().get(0).getHubProject();
         VERSION_NAME = blackDuckFortifyMappers.get(0).getHubProjectVersion().get(0).getHubProjectVersion();
     }
@@ -73,8 +80,8 @@ public class HubServicesTest extends TestCase {
         ProjectView project = null;
         List<ProjectVersionView> projectVersionViews = new ArrayList<>();
         try {
-            project = springConfiguration.getHubServices().getProjectByProjectName(PROJECT_NAME);
-            projectVersionViews = springConfiguration.getHubServices().getProjectVersionsByProject(project);
+            project = hubServices.getProjectByProjectName(PROJECT_NAME);
+            projectVersionViews = hubServices.getProjectVersionsByProject(project);
         } catch (IllegalArgumentException e) {
             e.printStackTrace();
         } catch (IntegrationException e) {
@@ -88,7 +95,7 @@ public class HubServicesTest extends TestCase {
         System.out.println("Executing getProjectVersion");
         ProjectVersionView projectVersionItem = null;
         try {
-            projectVersionItem = springConfiguration.getHubServices().getProjectVersion(PROJECT_NAME, VERSION_NAME);
+            projectVersionItem = hubServices.getProjectVersion(PROJECT_NAME, VERSION_NAME);
         } catch (IllegalArgumentException e) {
             e.printStackTrace();
         } catch (IntegrationException e) {
@@ -102,7 +109,7 @@ public class HubServicesTest extends TestCase {
         System.out.println("Executing getProjectVersionWithInvalidProjectName");
         ProjectVersionView projectVersionItem = null;
         try {
-            projectVersionItem = springConfiguration.getHubServices().getProjectVersion("Solr1", VERSION_NAME);
+            projectVersionItem = hubServices.getProjectVersion("Solr1", VERSION_NAME);
         } catch (IllegalArgumentException e) {
             e.printStackTrace();
         } catch (IntegrationException e) {
@@ -118,7 +125,7 @@ public class HubServicesTest extends TestCase {
         System.out.println("Executing getProjectVersionWithInvalidVersionName");
         ProjectVersionView projectVersionItem = null;
         try {
-            projectVersionItem = springConfiguration.getHubServices().getProjectVersion(PROJECT_NAME, "3.10");
+            projectVersionItem = hubServices.getProjectVersion(PROJECT_NAME, "3.10");
         } catch (IllegalArgumentException e) {
             e.printStackTrace();
         } catch (IntegrationException e) {
@@ -134,13 +141,13 @@ public class HubServicesTest extends TestCase {
         System.out.println("Executing getVulnerability");
         ProjectVersionView projectVersionItem = null;
         try {
-            projectVersionItem = springConfiguration.getHubServices().getProjectVersion(PROJECT_NAME, VERSION_NAME);
+            projectVersionItem = hubServices.getProjectVersion(PROJECT_NAME, VERSION_NAME);
         } catch (IllegalArgumentException e) {
             e.printStackTrace();
         } catch (IntegrationException e) {
             e.printStackTrace();
         }
-        List<VulnerableComponentView> vulnerableComponentViews = springConfiguration.getHubServices().getVulnerabilityComponentViews(projectVersionItem);
+        List<VulnerableComponentView> vulnerableComponentViews = hubServices.getVulnerabilityComponentViews(projectVersionItem);
         System.out.println("vulnerableComponentViews size::" + vulnerableComponentViews.size() + ", vulnerableComponentViews::" + vulnerableComponentViews);
         assertNotNull(vulnerableComponentViews);
     }
@@ -150,13 +157,13 @@ public class HubServicesTest extends TestCase {
         System.out.println("Executing getBomLastUpdatedAt");
         ProjectVersionView projectVersionItem = null;
         try {
-            projectVersionItem = springConfiguration.getHubServices().getProjectVersion(PROJECT_NAME, VERSION_NAME);
+            projectVersionItem = hubServices.getProjectVersion(PROJECT_NAME, VERSION_NAME);
         } catch (IllegalArgumentException e) {
             e.printStackTrace();
         } catch (IntegrationException e) {
             e.printStackTrace();
         }
-        Date bomLastUpdatedAt = springConfiguration.getHubServices().getBomLastUpdatedAt(projectVersionItem);
+        Date bomLastUpdatedAt = hubServices.getBomLastUpdatedAt(projectVersionItem);
         System.out.println("bomLastUpdatedAt::" + bomLastUpdatedAt);
         assertNotNull(bomLastUpdatedAt);
     }

--- a/src/test/java/com/blackducksoftware/integration/fortify/batch/util/MappingParserTest.java
+++ b/src/test/java/com/blackducksoftware/integration/fortify/batch/util/MappingParserTest.java
@@ -28,12 +28,16 @@ import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import com.blackducksoftware.integration.exception.IntegrationException;
+import com.blackducksoftware.integration.fortify.batch.BatchSchedulerConfig;
 import com.blackducksoftware.integration.fortify.batch.TestApplication;
 import com.blackducksoftware.integration.fortify.batch.job.BlackDuckFortifyJobConfig;
+import com.blackducksoftware.integration.fortify.batch.job.SpringConfiguration;
 import com.blackducksoftware.integration.fortify.batch.model.BlackDuckFortifyMapperGroup;
 import com.google.gson.JsonIOException;
 
@@ -47,9 +51,13 @@ import junit.framework.TestCase;
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(classes = TestApplication.class)
+@ContextConfiguration(classes = { SpringConfiguration.class, BlackDuckFortifyJobConfig.class, BatchSchedulerConfig.class, PropertyConstants.class })
 public class MappingParserTest extends TestCase {
 
     private BlackDuckFortifyJobConfig blackDuckFortifyJobConfig;
+
+    @Autowired
+    private PropertyConstants propertyConstants;
 
     @Override
     @Before
@@ -62,7 +70,7 @@ public class MappingParserTest extends TestCase {
         System.out.println("Executing testMappingFileParser");
         List<BlackDuckFortifyMapperGroup> mapping;
         try {
-            mapping = blackDuckFortifyJobConfig.getMappingParser().createMapping(PropertyConstants.getMappingJsonPath());
+            mapping = blackDuckFortifyJobConfig.getMappingParser().createMapping(propertyConstants.getMappingJsonPath());
             assertNotNull(mapping);
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/test/java/com/blackducksoftware/integration/fortify/batch/util/VulnerabilityUtilTest.java
+++ b/src/test/java/com/blackducksoftware/integration/fortify/batch/util/VulnerabilityUtilTest.java
@@ -36,10 +36,13 @@ import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import com.blackducksoftware.integration.exception.IntegrationException;
+import com.blackducksoftware.integration.fortify.batch.BatchSchedulerConfig;
 import com.blackducksoftware.integration.fortify.batch.TestApplication;
 import com.blackducksoftware.integration.fortify.batch.job.BlackDuckFortifyJobConfig;
 import com.blackducksoftware.integration.fortify.batch.job.SpringConfiguration;
@@ -52,6 +55,7 @@ import junit.framework.TestCase;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(classes = TestApplication.class)
+@ContextConfiguration(classes = { SpringConfiguration.class, BlackDuckFortifyJobConfig.class, BatchSchedulerConfig.class, PropertyConstants.class })
 public class VulnerabilityUtilTest extends TestCase {
     private String HUB_PROJECT_NAME_1;
 
@@ -61,17 +65,20 @@ public class VulnerabilityUtilTest extends TestCase {
 
     private String HUB_PROJECT_VERSION_NAME_2;
 
-    private BlackDuckFortifyJobConfig blackDuckFortifyJobConfig;
+    @Autowired
+    private HubServices hubServices;
 
-    private SpringConfiguration springConfiguration;
+    @Autowired
+    private MappingParser mappingParser;
+
+    @Autowired
+    private PropertyConstants propertyConstants;
 
     @Override
     @Before
     public void setUp() throws JsonIOException, IOException, IntegrationException {
-        blackDuckFortifyJobConfig = new BlackDuckFortifyJobConfig();
-        springConfiguration = new SpringConfiguration();
-        final List<BlackDuckFortifyMapperGroup> blackDuckFortifyMappers = blackDuckFortifyJobConfig.getMappingParser()
-                .createMapping(PropertyConstants.getMappingJsonPath());
+        final List<BlackDuckFortifyMapperGroup> blackDuckFortifyMappers = mappingParser
+                .createMapping(propertyConstants.getMappingJsonPath());
         HUB_PROJECT_NAME_1 = blackDuckFortifyMappers.get(0).getHubProjectVersion().get(0).getHubProject();
         HUB_PROJECT_VERSION_NAME_1 = blackDuckFortifyMappers.get(0).getHubProjectVersion().get(0).getHubProjectVersion();
         HUB_PROJECT_NAME_2 = blackDuckFortifyMappers.get(1).getHubProjectVersion().get(0).getHubProject();
@@ -84,7 +91,7 @@ public class VulnerabilityUtilTest extends TestCase {
         List<Vulnerability> vulnerabilities = new ArrayList<>();
         try {
             try (Writer writer = new BufferedWriter(
-                    new OutputStreamWriter(new FileOutputStream(PropertyConstants.getBatchJobStatusFilePath()), "utf-8"))) {
+                    new OutputStreamWriter(new FileOutputStream(propertyConstants.getBatchJobStatusFilePath()), "utf-8"))) {
                 writer.write("");
             } catch (UnsupportedEncodingException e) {
                 // do nothing
@@ -94,16 +101,16 @@ public class VulnerabilityUtilTest extends TestCase {
                 // do nothing
             }
 
-            ProjectVersionView projectVersionItem1 = springConfiguration.getHubServices().getProjectVersion(HUB_PROJECT_NAME_1,
+            ProjectVersionView projectVersionItem1 = hubServices.getProjectVersion(HUB_PROJECT_NAME_1,
                     HUB_PROJECT_VERSION_NAME_1);
-            ProjectVersionView projectVersionItem2 = springConfiguration.getHubServices().getProjectVersion(HUB_PROJECT_NAME_2,
+            ProjectVersionView projectVersionItem2 = hubServices.getProjectVersion(HUB_PROJECT_NAME_2,
                     HUB_PROJECT_VERSION_NAME_2);
             vulnerabilities
-                    .addAll(VulnerabilityUtil.transformMapping(springConfiguration.getHubServices().getVulnerabilityComponentViews(projectVersionItem1),
-                            HUB_PROJECT_NAME_1, HUB_PROJECT_VERSION_NAME_1, new Date()));
+                    .addAll(VulnerabilityUtil.transformMapping(hubServices.getVulnerabilityComponentViews(projectVersionItem1),
+                            HUB_PROJECT_NAME_1, HUB_PROJECT_VERSION_NAME_1, new Date(), propertyConstants));
             vulnerabilities
-                    .addAll(VulnerabilityUtil.transformMapping(springConfiguration.getHubServices().getVulnerabilityComponentViews(projectVersionItem2),
-                            HUB_PROJECT_NAME_2, HUB_PROJECT_VERSION_NAME_2, new Date()));
+                    .addAll(VulnerabilityUtil.transformMapping(hubServices.getVulnerabilityComponentViews(projectVersionItem2),
+                            HUB_PROJECT_NAME_2, HUB_PROJECT_VERSION_NAME_2, new Date(), propertyConstants));
 
             vulnerabilities = VulnerabilityUtil.removeDuplicates(vulnerabilities);
 

--- a/src/test/java/com/blackducksoftware/integration/fortify/service/FortifyAttributeDefinitionApiTest.java
+++ b/src/test/java/com/blackducksoftware/integration/fortify/service/FortifyAttributeDefinitionApiTest.java
@@ -24,33 +24,34 @@ package com.blackducksoftware.integration.fortify.service;
 
 import java.io.IOException;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import com.blackducksoftware.integration.exception.IntegrationException;
+import com.blackducksoftware.integration.fortify.batch.BatchSchedulerConfig;
 import com.blackducksoftware.integration.fortify.batch.TestApplication;
 import com.blackducksoftware.integration.fortify.batch.job.BlackDuckFortifyJobConfig;
+import com.blackducksoftware.integration.fortify.batch.job.SpringConfiguration;
+import com.blackducksoftware.integration.fortify.batch.util.PropertyConstants;
 import com.blackducksoftware.integration.fortify.model.FortifyAttributeDefinitionResponse;
 
 import junit.framework.TestCase;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(classes = { TestApplication.class })
+@ContextConfiguration(classes = { SpringConfiguration.class, BlackDuckFortifyJobConfig.class, BatchSchedulerConfig.class, PropertyConstants.class })
 public class FortifyAttributeDefinitionApiTest extends TestCase {
-    private BlackDuckFortifyJobConfig blackDuckFortifyJobConfig;
 
-    @Override
-    @Before
-    public void setUp() {
-        blackDuckFortifyJobConfig = new BlackDuckFortifyJobConfig();
-    }
+    @Autowired
+    private FortifyAttributeDefinitionApi fortifyAttributeDefinitionApi;
 
     @Test
     public void getApplicationAttributeDefinition() throws IOException, IntegrationException {
-        FortifyAttributeDefinitionResponse fortifyAttributeDefintionResponse = blackDuckFortifyJobConfig.getFortifyAttributeDefinitionApi()
+        FortifyAttributeDefinitionResponse fortifyAttributeDefintionResponse = fortifyAttributeDefinitionApi
                 .getAttributeDefinitions();
         System.out.println(fortifyAttributeDefintionResponse);
         assertNotNull(fortifyAttributeDefintionResponse);

--- a/src/test/java/com/blackducksoftware/integration/fortify/service/FortifyFileTokenApiTest.java
+++ b/src/test/java/com/blackducksoftware/integration/fortify/service/FortifyFileTokenApiTest.java
@@ -23,35 +23,36 @@
 package com.blackducksoftware.integration.fortify.service;
 
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
+import com.blackducksoftware.integration.fortify.batch.BatchSchedulerConfig;
 import com.blackducksoftware.integration.fortify.batch.TestApplication;
 import com.blackducksoftware.integration.fortify.batch.job.BlackDuckFortifyJobConfig;
+import com.blackducksoftware.integration.fortify.batch.job.SpringConfiguration;
+import com.blackducksoftware.integration.fortify.batch.util.PropertyConstants;
 import com.blackducksoftware.integration.fortify.model.FileToken;
 
 import junit.framework.TestCase;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(classes = TestApplication.class)
+@ContextConfiguration(classes = { SpringConfiguration.class, BlackDuckFortifyJobConfig.class, BatchSchedulerConfig.class, PropertyConstants.class })
 public class FortifyFileTokenApiTest extends TestCase {
-    private BlackDuckFortifyJobConfig blackDuckFortifyJobConfig;
 
-    @Override
-    @Before
-    public void setUp() {
-        blackDuckFortifyJobConfig = new BlackDuckFortifyJobConfig();
-    }
+    @Autowired
+    private FortifyFileTokenApi fortifyFileTokenApi;
 
     @Test
     public void getFileToken() throws Exception {
         System.out.println("Executing getFileToken");
         FileToken fileToken = new FileToken("UPLOAD");
 
-        String fileTokenResponse = blackDuckFortifyJobConfig.getFortifyFileTokenApi().getFileToken(fileToken);
+        String fileTokenResponse = fortifyFileTokenApi.getFileToken(fileToken);
         System.out.println("fileTokenResponse::" + fileTokenResponse);
         Assert.assertNotNull(fileTokenResponse);
     }
@@ -59,7 +60,7 @@ public class FortifyFileTokenApiTest extends TestCase {
     @Test
     public void deleteFileToken() throws Exception {
         System.out.println("Executing deleteFileToken");
-        blackDuckFortifyJobConfig.getFortifyFileTokenApi().deleteFileToken();
+        fortifyFileTokenApi.deleteFileToken();
     }
 
 }

--- a/src/test/java/com/blackducksoftware/integration/fortify/service/FortifyUploadApiTest.java
+++ b/src/test/java/com/blackducksoftware/integration/fortify/service/FortifyUploadApiTest.java
@@ -25,35 +25,39 @@ package com.blackducksoftware.integration.fortify.service;
 import java.io.File;
 
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
+import com.blackducksoftware.integration.fortify.batch.BatchSchedulerConfig;
 import com.blackducksoftware.integration.fortify.batch.TestApplication;
 import com.blackducksoftware.integration.fortify.batch.job.BlackDuckFortifyJobConfig;
+import com.blackducksoftware.integration.fortify.batch.job.SpringConfiguration;
+import com.blackducksoftware.integration.fortify.batch.util.PropertyConstants;
 import com.blackducksoftware.integration.fortify.model.FileToken;
 
 import junit.framework.TestCase;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(classes = TestApplication.class)
+@ContextConfiguration(classes = { SpringConfiguration.class, BlackDuckFortifyJobConfig.class, BatchSchedulerConfig.class, PropertyConstants.class })
 public class FortifyUploadApiTest extends TestCase {
-    private BlackDuckFortifyJobConfig blackDuckFortifyJobConfig;
 
-    @Override
-    @Before
-    public void setUp() {
-        blackDuckFortifyJobConfig = new BlackDuckFortifyJobConfig();
-    }
+    @Autowired
+    private FortifyUploadApi fortifyUploadApi;
+
+    @Autowired
+    private FortifyFileTokenApi fortifyFileTokenApi;
 
     @Test
     public void uploadCSVFile() throws Exception {
         System.out.println("Executing uploadCSVFile");
         FileToken fileToken = new FileToken("UPLOAD");
 
-        String fileTokenResponse = blackDuckFortifyJobConfig.getFortifyFileTokenApi().getFileToken(fileToken);
+        String fileTokenResponse = fortifyFileTokenApi.getFileToken(fileToken);
         System.out.println("File Token::" + fileTokenResponse);
         Assert.assertNotNull(fileTokenResponse);
 
@@ -63,7 +67,7 @@ public class FortifyUploadApiTest extends TestCase {
         // File("/Users/smanikantan/Documents/hub-fortify-integration/report/solrWar2_4.10.4_20170510160506866.csv");
         System.out.println("file::" + file);
 
-        boolean response = blackDuckFortifyJobConfig.getFortifyUploadApi().uploadVulnerabilityByProjectVersion(fileTokenResponse, 2l, file);
+        boolean response = fortifyUploadApi.uploadVulnerabilityByProjectVersion(fileTokenResponse, 2l, file);
         System.out.println("uploadVulnerabilityResponse::" + response);
         Assert.assertTrue(response);
     }


### PR DESCRIPTION
**Description:**
Added a new job to send usage data to Black Duck. This job runs on the
same schedule as the push scan data task. In the process refactored code
so that PropertyConstants and AttributeConstants were no longer
statically accessible (accessing the static variables when the Spring
bean was being instantiated caused null return values and consequently
validation method were failing).

* Edited application.properties and application_prod.properties to have
a placeholder for the plugin version, and edited the build.gradle to
fill in that placeholder using values from the project.properties.
* Ensure PropertyConstants and AttributeConstants are loaded as Spring
Beans
* Removed `static` keyword from all PropertyConstants and
AttributeConstants fields and methods.
* Edited all locations where PropertyConstants and/or AttributeConstants
were used to either provide a Dependency Injected bean or pass the bean
through the constructor for non- spring bean classes
* Added new Job Configuration and Step classes for Phone Home
capability. Job runs on the same schedule as the push scan data task
* Modified all JUnit tests to use Dependency Injected beans where
possible

**Reviewers:**
@robpacheco 
@skatzman 
@msenmurugan 