### PR TITLE
Minor refactoring

### DIFF
--- a/src/main/java/com/blackducksoftware/integration/fortify/batch/BatchSchedulerConfig.java
+++ b/src/main/java/com/blackducksoftware/integration/fortify/batch/BatchSchedulerConfig.java
@@ -22,6 +22,7 @@
  */
 package com.blackducksoftware.integration.fortify.batch;
 
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.batch.core.launch.support.SimpleJobLauncher;
 import org.springframework.batch.core.repository.JobRepository;
@@ -39,6 +40,7 @@ import org.springframework.transaction.PlatformTransactionManager;
  *
  */
 @Configuration
+@EnableBatchProcessing
 @EnableScheduling
 public class BatchSchedulerConfig {
 

--- a/src/main/java/com/blackducksoftware/integration/fortify/batch/job/BlackDuckFortifyJobConfig.java
+++ b/src/main/java/com/blackducksoftware/integration/fortify/batch/job/BlackDuckFortifyJobConfig.java
@@ -31,20 +31,18 @@ import org.springframework.batch.core.JobExecutionListener;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.Step;
-import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
 import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
 import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
 import org.springframework.batch.core.launch.support.RunIdIncrementer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.task.SimpleAsyncTaskExecutor;
-import org.springframework.core.task.TaskExecutor;
 import org.springframework.scheduling.annotation.Scheduled;
 
 import com.blackducksoftware.integration.fortify.batch.BatchSchedulerConfig;
 import com.blackducksoftware.integration.fortify.batch.step.Initializer;
 import com.blackducksoftware.integration.fortify.batch.util.AttributeConstants;
+import com.blackducksoftware.integration.fortify.batch.util.HubServices;
 import com.blackducksoftware.integration.fortify.batch.util.MappingParser;
 import com.blackducksoftware.integration.fortify.batch.util.PropertyConstants;
 import com.blackducksoftware.integration.fortify.service.FortifyApplicationVersionApi;
@@ -59,7 +57,6 @@ import com.blackducksoftware.integration.fortify.service.FortifyUploadApi;
  *
  */
 @Configuration
-@EnableBatchProcessing
 public class BlackDuckFortifyJobConfig implements JobExecutionListener {
     private final static Logger logger = Logger.getLogger(BlackDuckFortifyJobConfig.class);
 
@@ -71,6 +68,9 @@ public class BlackDuckFortifyJobConfig implements JobExecutionListener {
 
     @Autowired
     private StepBuilderFactory stepBuilderFactory;
+
+    @Autowired
+    private HubServices hubServices;
 
     @Autowired
     private PropertyConstants propertyConstants;
@@ -135,19 +135,7 @@ public class BlackDuckFortifyJobConfig implements JobExecutionListener {
      */
     @Bean
     public Initializer getMappingParserTask() {
-        return new Initializer(getMappingParser(), getFortifyFileTokenApi(), getFortifyUploadApi(), propertyConstants);
-    }
-
-    /**
-     * Create the task executor which will be used for multi-threading
-     *
-     * @return TaskExecutor
-     */
-    @Bean
-    public TaskExecutor taskExecutor() {
-        SimpleAsyncTaskExecutor asyncTaskExecutor = new SimpleAsyncTaskExecutor("spring_batch");
-        asyncTaskExecutor.setConcurrencyLimit(1);
-        return asyncTaskExecutor;
+        return new Initializer(getMappingParser(), getFortifyFileTokenApi(), getFortifyUploadApi(), hubServices, propertyConstants);
     }
 
     /**

--- a/src/main/java/com/blackducksoftware/integration/fortify/batch/job/SpringConfiguration.java
+++ b/src/main/java/com/blackducksoftware/integration/fortify/batch/job/SpringConfiguration.java
@@ -24,6 +24,8 @@ package com.blackducksoftware.integration.fortify.batch.job;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
+import org.springframework.core.task.TaskExecutor;
 
 import com.blackducksoftware.integration.fortify.batch.util.HubServices;
 import com.blackducksoftware.integration.fortify.batch.util.PropertyConstants;
@@ -39,5 +41,17 @@ public class SpringConfiguration {
     @Bean
     public HubServices getHubServices(PropertyConstants propertyConstants) {
         return new HubServices(RestConnectionHelper.createHubServicesFactory(propertyConstants));
+    }
+
+    /**
+     * Create the task executor which will be used for multi-threading
+     *
+     * @return TaskExecutor
+     */
+    @Bean
+    public TaskExecutor taskExecutor() {
+        SimpleAsyncTaskExecutor asyncTaskExecutor = new SimpleAsyncTaskExecutor("spring_batch");
+        asyncTaskExecutor.setConcurrencyLimit(SimpleAsyncTaskExecutor.NO_CONCURRENCY);
+        return asyncTaskExecutor;
     }
 }

--- a/src/main/java/com/blackducksoftware/integration/fortify/batch/step/BlackDuckFortifyPhoneHomeStep.java
+++ b/src/main/java/com/blackducksoftware/integration/fortify/batch/step/BlackDuckFortifyPhoneHomeStep.java
@@ -11,8 +11,7 @@
  */
 package com.blackducksoftware.integration.fortify.batch.step;
 
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
+import java.util.Date;
 
 import org.apache.log4j.Logger;
 import org.springframework.batch.core.ExitStatus;
@@ -37,8 +36,6 @@ import com.blackducksoftware.integration.phonehome.enums.ThirdPartyName;
 public class BlackDuckFortifyPhoneHomeStep implements Tasklet, StepExecutionListener {
     private final static Logger logger = Logger.getLogger(BlackDuckFortifyPhoneHomeStep.class);
 
-    private String startJobTimeStamp;
-
     private final HubServices hubServices;
 
     private final PropertyConstants propertyConstants;
@@ -59,7 +56,6 @@ public class BlackDuckFortifyPhoneHomeStep implements Tasklet, StepExecutionList
      */
     @Override
     public void beforeStep(StepExecution stepExecution) {
-        startJobTimeStamp = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss.SSS").format(LocalDateTime.now());
     }
 
     /**
@@ -67,9 +63,12 @@ public class BlackDuckFortifyPhoneHomeStep implements Tasklet, StepExecutionList
      */
     @Override
     public ExitStatus afterStep(StepExecution stepExecution) {
-        String stopJobTimeStamp = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss.SSS").format(LocalDateTime.now());
-        logger.info("Phone Home execution step started: " + startJobTimeStamp + " and ended: " + stopJobTimeStamp);
-        return ExitStatus.COMPLETED;
+        /**
+         * See http://forum.spring.io/forum/spring-projects/batch/123268-endtime-not-set-on-stepexecution for
+         * discussion on why StepExecution.endTime is null when the listener is called.
+         */
+        logger.info("Phone Home execution step started: " + stepExecution.getStartTime() + " and ended: " + new Date());
+        return null;
     }
 
     @Override

--- a/src/main/java/com/blackducksoftware/integration/fortify/batch/util/RestConnectionHelper.java
+++ b/src/main/java/com/blackducksoftware/integration/fortify/batch/util/RestConnectionHelper.java
@@ -22,6 +22,8 @@
  */
 package com.blackducksoftware.integration.fortify.batch.util;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.log4j.Logger;
 
 import com.blackducksoftware.integration.exception.EncryptionException;
@@ -33,6 +35,8 @@ import com.blackducksoftware.integration.hub.service.HubServicesFactory;
 import com.blackducksoftware.integration.log.IntLogger;
 import com.blackducksoftware.integration.log.LogLevel;
 import com.blackducksoftware.integration.log.PrintStreamIntLogger;
+
+import okhttp3.ConnectionPool;
 
 /**
  * This class is used to get the Hub REST connection
@@ -147,6 +151,9 @@ public final class RestConnectionHelper {
     private static HubServicesFactory createHubServicesFactory(final IntLogger logger, final PropertyConstants propertyConstants) {
         final RestConnection restConnection = getApplicationPropertyRestConnection(propertyConstants);
         restConnection.logger = logger;
+        // Adjust the number of connections in the connection pool. The keepAlive info is the same as the default
+        // constructor
+        restConnection.builder.connectionPool(new ConnectionPool(propertyConstants.getMaximumThreadSize(), 5, TimeUnit.MINUTES));
         final HubServicesFactory hubServicesFactory = new HubServicesFactory(restConnection);
         return hubServicesFactory;
     }


### PR DESCRIPTION
**Description:**
* Adjust the max idle connections in the connection pool of the
RestConnection object
* Remove the creation of multiple HubServices objects in the Initializer
constructor and the use of a random number to select one to use in the
thread
* Remove the multiple TaskExecutor bean definitions and place the bean
definition in a common location
* Use the start time and end times provided by the Execution objects in
the listener code of Phone Home
* Modified the return of _afterStep_ to _null_ so the step's exit status
is unchanged
* Removed multiple references to _EnableBatchProcessing_ annotation and
place a single reference in a common location